### PR TITLE
Fix validation for ETH addresses starting with 0x0

### DIFF
--- a/coinaddr/validation.py
+++ b/coinaddr/validation.py
@@ -114,7 +114,9 @@ class EthereumValidator(ValidatorBase):
         if any(bool(pat.match(address))
                for pat in self.non_checksummed_patterns):
             return True
-        addr = address.lstrip('0x')
+        if not address.startswith('0x'):
+            return False
+        addr = address[2:]
         addr_hash = sha3.keccak_256(addr.lower().encode('ascii')).hexdigest()
         for i in range(0, len(addr)):
             if any([


### PR DESCRIPTION
This PR fixes a bug with validating all ETH addresses which start with 0x0.
Even though such addresses are valid, the validator marked them as invalid, because 
lstrip stripped one char too many.

`>>>'0x0b240090ec72A9'.lstrip('0x')`
`>>> b240090ec72A9`

[link to the docs about lstrip](https://docs.python.org/3.8/library/stdtypes.html?highlight=strip#str.lstrip)