### PR TITLE
Fix validation for invalid Base58 addresses

### DIFF
--- a/coinaddr/validation.py
+++ b/coinaddr/validation.py
@@ -97,6 +97,7 @@ class Base58CheckValidator(ValidatorBase):
             if nbyte in networks:
                 return name
 
+        return ''
 
 @attr.s(frozen=True, slots=True, eq=False)
 @implementer(IValidator)


### PR DESCRIPTION
If the address is invalid we can't derive the network from it so
we must return an empty string to avoid hitting an exception
later on.

e.g. TypeError: ("'network' must be <class 'str'> (got None that is a <class 'NoneType'>).",
To return an empty network string for when the address is invalid. Seems almost all bug reports are about this same issue.